### PR TITLE
disable svc:/network/dns/client by default

### DIFF
--- a/config/profile.xml
+++ b/config/profile.xml
@@ -20,6 +20,15 @@
     </service>
 
 <!--
+    Disable the dns/client service by default. Most Omicron zones do not need
+    this and those that do will configure and then enable it as part of
+    service setup:
+-->
+    <service name='network/dns/client' version='1' type='service'>
+        <instance name='default' enabled='false' />
+    </service>
+
+<!--
     Disable any other services that we do not expect to need within an Omicron
     zone:
 -->


### PR DESCRIPTION
Almost all Omicron zones do not have `/etc/resolv.conf` and so the `dns/client` service stays offline and included in the output of `svcs -x`.
Let's disable it by default in the brand profile, and the zones that do create /etc/resolv.conf (currently just NTP zones, in the future possibly nexus too) can enable the service if they wish (although it doesn't do a great deal past dependencies).