### PR TITLE
replicate global zone /etc/default/init in new zones

### DIFF
--- a/brand/src/bin/brand.rs
+++ b/brand/src/bin/brand.rs
@@ -282,6 +282,17 @@ fn cmd_install(
         extra.unpack(&root)?;
     }
 
+    /*
+     * Copy in configuration files from the global zone.
+     */
+    for cf in ["default/init"] {
+        let src = format!("/etc/{cf}");
+        println!("INFO: omicron: copying {src}...");
+        let dst = s.zonerootpath(&["etc", cf]);
+        std::fs::remove_file(&dst).ok();
+        std::fs::copy(src, dst)?;
+    }
+
     println!("INFO: omicron: install complete, probably!");
 
     Ok(())


### PR DESCRIPTION
This change is a quick update to address #4 - fixes #4
The differing timezones between the GZ and an NGZ caused confusion during a recent debugging session.

This isn't the approach suggested in #4, instead we just copy the GZ's init file into the new zone after extracting the baseline archive, so that a new zone's timezone and umask match the GZ at the time of creation.

```
gimlet-sn06 # testzone
test: No such zone configured
Use 'create' to begin configuring a new zone.
A ZFS file system has been created for this zone.
INFO: omicron: installing zone test @ "/zones/test"...
INFO: omicron: replicating /usr tree...
INFO: omicron: replicating /lib tree...
INFO: omicron: replicating /sbin tree...
INFO: omicron: pruning SMF manifests...
INFO: omicron: pruning global-only files...
INFO: omicron: unpacking baseline archive...
INFO: omicron: copying /etc/default/init...
INFO: omicron: install complete, probably!
gimlet-sn06 # cat /zones/test/root/etc/default/init
#
# This file is /etc/default/init.
# This file looks like a shell script, but it is not.
#
# Lines of this file should be of the form VAR=value, where VAR is one of
# TZ, LANG, CMASK, or any of the LC_* environment variables.  value may
# be enclosed in double quotes (") or single quotes (').
#
TZ=UTC
CMASK=022
```
