### PR TITLE
Allow dtrace_kernel in the zone

### DIFF
--- a/config/config.xml
+++ b/config/config.xml
@@ -80,7 +80,6 @@
     <privilege set="default" name="sys_resource" />
     <privilege set="default" name="sys_smb" />
 
-    <privilege set="prohibited" name="dtrace_kernel" />
     <privilege set="prohibited" name="proc_zone" />
     <privilege set="prohibited" name="sys_config" />
     <privilege set="prohibited" name="sys_devices" />


### PR DESCRIPTION
Allow `dtrace_kernel` in the zone.

We wanted this for the `oxz_switch` zone.
Thinking about the principle of least permissions, Is allowing it here opening the door to much?  
Only zones that specifically request it will have it.