### PR TITLE
improve performance of zone install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Oxide Computer Company
+# Copyright 2024 Oxide Computer Company
 #
 
 TOP =		$(PWD)
@@ -14,10 +14,12 @@ BRAND =		omicron1
 BRANDDIR =	usr/lib/brand/$(BRAND)
 MAN7DIR =	usr/share/man/man7
 SMFDIR =	lib/svc/manifest/system/omicron
+DEFDIR =	etc/default
 
 DIRS_0 =	$(BRANDDIR) \
 		$(MAN7DIR) \
-		$(SMFDIR)
+		$(SMFDIR) \
+		$(DEFDIR)
 DIRS =		$(DIRS_0:%=$(PROTO)/%)
 
 SMF_0 =		baseline.xml
@@ -34,6 +36,9 @@ XML_0 =		config.xml \
 		platform.xml
 XML =		$(XML_0:%=$(PROTO)/$(BRANDDIR)/%)
 
+DEFAULTS_0 =	helios-omicron1
+DEFAULTS =	$(DEFAULTS_0:%=$(PROTO)/$(DEFDIR)/%)
+
 PACKAGES_0 =	brand \
 		baseline \
 		incorporation
@@ -42,7 +47,7 @@ PACKAGES =	$(PACKAGES_0:%=pkg.%)
 COMMIT_COUNT =	$(shell git rev-list --count HEAD)
 
 .PHONY: all
-all: $(DIRS) $(BINS) $(MAN7) $(SMF) $(XML)
+all: $(DIRS) $(BINS) $(MAN7) $(SMF) $(XML) $(DEFAULTS)
 
 .PHONY: package
 package: all $(PKGDIR) $(PACKAGES)
@@ -93,6 +98,10 @@ $(PROTO)/$(SMFDIR)/%: smf/%
 	cp $< $@
 
 $(PROTO)/$(BRANDDIR)/%.xml: config/%.xml
+	@rm -f $@
+	cp $< $@
+
+$(PROTO)/$(DEFDIR)/%: config/%
 	@rm -f $@
 	cp $< $@
 

--- a/config/helios-omicron1
+++ b/config/helios-omicron1
@@ -13,9 +13,9 @@
 # How many writer threads should we use when copying from the root file
 # system to a new zone root?
 #
-COPY_THREADS=16
+COPY_THREADS=8
 
 #
 # What batch size should the writer thread queue use?
 #
-COPY_BATCH=32
+COPY_BATCH=128

--- a/config/helios-omicron1
+++ b/config/helios-omicron1
@@ -1,0 +1,21 @@
+#
+# Copyright 2024 Oxide Computer Company
+#
+
+#
+# This file contains various tuning settings used by various Helios "omicron1"
+# brand tools that may be useful to override during experiments.  The format of
+# this file is not a Committed interface, and it is not expected that end users
+# or customers will need to alter it.
+#
+
+#
+# How many writer threads should we use when copying from the root file
+# system to a new zone root?
+#
+COPY_THREADS=16
+
+#
+# What batch size should the writer thread queue use?
+#
+COPY_BATCH=32

--- a/pkg/brand.p5m
+++ b/pkg/brand.p5m
@@ -12,6 +12,10 @@ set name=pkg.summary value="Oxide omicron1 brand support"
 set name=info.classification \
     value=org.opensolaris.category.2008:System/Virtualization
 set name=variant.opensolaris.zone value=global value=nonglobal
+dir  path=etc owner=root group=sys mode=0755
+dir  path=etc/default owner=root group=sys mode=0755
+file path=etc/default/helios-omicron1 owner=root group=bin mode=0644 \
+    preserve=true
 dir  path=usr owner=root group=sys mode=0755
 dir  path=usr/lib owner=root group=bin mode=0755
 dir  path=usr/lib/brand owner=root group=bin mode=0755

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/utils/src/copyq.rs
+++ b/utils/src/copyq.rs
@@ -3,6 +3,7 @@
  */
 
 use anyhow::{anyhow, Result};
+
 use std::{
     os::unix::prelude::{MetadataExt, OpenOptionsExt},
     path::PathBuf,
@@ -13,6 +14,8 @@ use std::{
 pub struct CopyQueue {
     inner: Arc<CopyQueueInner>,
     threads: Vec<thread::JoinHandle<std::result::Result<CopyStats, String>>>,
+    pending: Vec<CopyEntry>,
+    batch: usize,
 }
 
 #[derive(Default)]
@@ -24,14 +27,14 @@ struct CopyQueueInner {
 #[derive(Default)]
 struct CopyQueueLocked {
     fin: bool,
-    q: Vec<CopyEntry>,
+    q: Vec<Vec<CopyEntry>>,
 }
 
 impl CopyQueue {
     /**
      * Create a thread pool and work queue for copying files.
      */
-    pub fn new(threads: usize) -> Result<CopyQueue> {
+    pub fn new(threads: usize, batch: usize) -> Result<CopyQueue> {
         let cqi = Arc::new(CopyQueueInner::default());
 
         let threads = (0..threads)
@@ -46,17 +49,44 @@ impl CopyQueue {
         Ok(CopyQueue {
             inner: cqi,
             threads,
+            pending: vec![],
+            batch,
         })
+    }
+
+    pub fn dispatch(&mut self) {
+        let pending = std::mem::replace(&mut self.pending, Vec::new());
+        let mut locked = self.inner.locked.lock().unwrap();
+        locked.q.push(pending);
+        self.inner.cv.notify_one();
     }
 
     /**
      * Schedules a file copy operation in the thread pool and returns
      * immediately.
      */
-    pub fn push_copy(&self, src: PathBuf, dst: PathBuf) {
-        let mut locked = self.inner.locked.lock().unwrap();
-        locked.q.push(CopyEntry { src, dst });
-        self.inner.cv.notify_one();
+    pub fn push_copy(&mut self, src: PathBuf, dst: PathBuf) {
+        self.pending.push(CopyEntry::Copy { src, dst });
+
+        if self.pending.len() == self.batch {
+            self.dispatch();
+        }
+    }
+
+    pub fn push_relative_link(&mut self, src: PathBuf, dst: PathBuf) {
+        self.pending.push(CopyEntry::RelativeLink { src, dst });
+
+        if self.pending.len() == self.batch {
+            self.dispatch();
+        }
+    }
+
+    pub fn push_absolute_link(&mut self, src: String, dst: PathBuf) {
+        self.pending.push(CopyEntry::AbsoluteLink { src, dst });
+
+        if self.pending.len() == self.batch {
+            self.dispatch();
+        }
     }
 
     /**
@@ -64,7 +94,9 @@ impl CopyQueue {
      * the thread pool to exit.  Returns statistics about the copied files,
      * aggregated from all worker threads.
      */
-    pub fn join(self) -> Result<CopyStats> {
+    pub fn join(mut self) -> Result<CopyStats> {
+        self.dispatch();
+
         /*
          * Inform the worker threads that there are no more files to copy:
          */
@@ -87,9 +119,10 @@ impl CopyQueue {
     }
 }
 
-struct CopyEntry {
-    src: PathBuf,
-    dst: PathBuf,
+enum CopyEntry {
+    Copy { src: PathBuf, dst: PathBuf },
+    RelativeLink { src: PathBuf, dst: PathBuf },
+    AbsoluteLink { src: String, dst: PathBuf },
 }
 
 #[derive(Default, Debug)]
@@ -104,11 +137,11 @@ fn copy_thread(
     let mut cs = CopyStats { files: 0, bytes: 0 };
 
     loop {
-        let CopyEntry { src, dst } = {
+        let cv = {
             let mut locked = cqi.locked.lock().unwrap();
             loop {
-                if let Some(ce) = locked.q.pop() {
-                    break ce;
+                if let Some(cv) = locked.q.pop() {
+                    break cv;
                 } else {
                     if locked.fin {
                         return Ok(cs);
@@ -120,40 +153,67 @@ fn copy_thread(
             }
         };
 
-        let mkerror = |e| format!("copy {src:?} -> {dst:?}: {e}");
+        for work in cv {
+            match work {
+                CopyEntry::Copy { src, dst } => {
+                    let mkerror = |e| format!("copy {src:?} -> {dst:?}: {e}");
 
-        cs.files += 1;
-        std::fs::remove_file(&dst).ok();
+                    cs.files += 1;
+                    std::fs::remove_file(&dst).ok();
 
-        let fsrc = std::fs::OpenOptions::new()
-            .read(true)
-            .open(&src)
-            .map_err(mkerror)?;
-        let md = fsrc.metadata().map_err(mkerror)?;
-        assert!(md.is_file());
+                    let fsrc = std::fs::OpenOptions::new()
+                        .read(true)
+                        .open(&src)
+                        .map_err(mkerror)?;
+                    let md = fsrc.metadata().map_err(mkerror)?;
+                    assert!(md.is_file());
 
-        /*
-         * Create the target file with the correct mode.  We made sure to remove
-         * it earlier, so we should make sure we are creating it anew here.
-         */
-        let fdst = std::fs::OpenOptions::new()
-            .mode(md.mode())
-            .create_new(true)
-            .write(true)
-            .open(&dst)
-            .map_err(mkerror)?;
+                    /*
+                     * Create the target file with the correct mode.  We made
+                     * sure to remove it earlier, so we should make sure we are
+                     * creating it anew here.
+                     */
+                    let fdst = std::fs::OpenOptions::new()
+                        .mode(md.mode())
+                        .create_new(true)
+                        .write(true)
+                        .open(&dst)
+                        .map_err(mkerror)?;
 
-        /*
-         * The easiest way to copy a file, std::fs::copy(), appears to use a
-         * regrettably microscopic buffer for reads and writes.  To make things
-         * go quite a lot faster, create a buffered reader and writer with a
-         * large buffer and use std::io::copy() instead, which will size read
-         * and write calls based on that buffer size.
-         */
-        let cap = 1024 * 1024;
-        let mut bsrc = std::io::BufReader::with_capacity(cap, fsrc);
-        let mut bdst = std::io::BufWriter::with_capacity(cap, fdst);
+                    /*
+                     * The easiest way to copy a file, std::fs::copy(), appears
+                     * to use a regrettably microscopic buffer for reads and
+                     * writes.  To make things go quite a lot faster, create a
+                     * buffered reader and writer with a large buffer and use
+                     * std::io::copy() instead, which will size read and write
+                     * calls based on that buffer size.
+                     */
+                    let cap = 1024 * 1024;
+                    let mut bsrc = std::io::BufReader::with_capacity(cap, fsrc);
+                    let mut bdst = std::io::BufWriter::with_capacity(cap, fdst);
 
-        cs.bytes += std::io::copy(&mut bsrc, &mut bdst).map_err(mkerror)?;
+                    cs.bytes +=
+                        std::io::copy(&mut bsrc, &mut bdst).map_err(mkerror)?;
+                }
+
+                CopyEntry::RelativeLink { src, dst } => {
+                    let mke = |e| format!("rel link {src:?} -> {dst:?}: {e}");
+
+                    let linktarget = std::fs::read_link(&src).map_err(mke)?;
+
+                    /*
+                     * XXX remove first...
+                     */
+                    std::os::unix::fs::symlink(&linktarget, &dst)
+                        .map_err(mke)?;
+                }
+
+                CopyEntry::AbsoluteLink { src, dst } => {
+                    let mke = |e| format!("abs link {src:?} -> {dst:?}: {e}");
+
+                    std::os::unix::fs::symlink(&src, &dst).map_err(mke)?;
+                }
+            }
+        }
     }
 }

--- a/utils/src/copyq.rs
+++ b/utils/src/copyq.rs
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 Oxide Computer Company
+ */
+
+use anyhow::{anyhow, Result};
+use std::{
+    os::unix::prelude::{MetadataExt, OpenOptionsExt},
+    path::PathBuf,
+    sync::{Arc, Condvar, Mutex},
+    thread,
+};
+
+pub struct CopyQueue {
+    inner: Arc<CopyQueueInner>,
+    threads: Vec<thread::JoinHandle<std::result::Result<CopyStats, String>>>,
+}
+
+#[derive(Default)]
+struct CopyQueueInner {
+    cv: Condvar,
+    locked: Mutex<CopyQueueLocked>,
+}
+
+#[derive(Default)]
+struct CopyQueueLocked {
+    fin: bool,
+    q: Vec<CopyEntry>,
+}
+
+impl CopyQueue {
+    /**
+     * Create a thread pool and work queue for copying files.
+     */
+    pub fn new(threads: usize) -> Result<CopyQueue> {
+        let cqi = Arc::new(CopyQueueInner::default());
+
+        let threads = (0..threads)
+            .map(|_| {
+                let cqi = Arc::clone(&cqi);
+                Ok(thread::Builder::new()
+                    .name("copy".into())
+                    .spawn(|| copy_thread(cqi))?)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(CopyQueue {
+            inner: cqi,
+            threads,
+        })
+    }
+
+    /**
+     * Schedules a file copy operation in the thread pool and returns
+     * immediately.
+     */
+    pub fn push_copy(&self, src: PathBuf, dst: PathBuf) {
+        let mut locked = self.inner.locked.lock().unwrap();
+        locked.q.push(CopyEntry { src, dst });
+        self.inner.cv.notify_one();
+    }
+
+    /**
+     * Waits for all enqueued file copies to complete and all of the threads in
+     * the thread pool to exit.  Returns statistics about the copied files,
+     * aggregated from all worker threads.
+     */
+    pub fn join(self) -> Result<CopyStats> {
+        /*
+         * Inform the worker threads that there are no more files to copy:
+         */
+        self.inner.locked.lock().unwrap().fin = true;
+        self.inner.cv.notify_all();
+
+        let mut tcs = CopyStats::default();
+
+        for t in self.threads {
+            let cs = t
+                .join()
+                .unwrap()
+                .map_err(|e| anyhow!("copy thread: {e:?}"))?;
+
+            tcs.files += cs.files;
+            tcs.bytes += cs.bytes;
+        }
+
+        Ok(tcs)
+    }
+}
+
+struct CopyEntry {
+    src: PathBuf,
+    dst: PathBuf,
+}
+
+#[derive(Default, Debug)]
+pub struct CopyStats {
+    pub files: u64,
+    pub bytes: u64,
+}
+
+fn copy_thread(
+    cqi: Arc<CopyQueueInner>,
+) -> std::result::Result<CopyStats, String> {
+    let mut cs = CopyStats { files: 0, bytes: 0 };
+
+    loop {
+        let CopyEntry { src, dst } = {
+            let mut locked = cqi.locked.lock().unwrap();
+            loop {
+                if let Some(ce) = locked.q.pop() {
+                    break ce;
+                } else {
+                    if locked.fin {
+                        return Ok(cs);
+                    }
+
+                    locked = cqi.cv.wait(locked).unwrap();
+                    continue;
+                }
+            }
+        };
+
+        let mkerror = |e| format!("copy {src:?} -> {dst:?}: {e}");
+
+        cs.files += 1;
+        std::fs::remove_file(&dst).ok();
+
+        let fsrc = std::fs::OpenOptions::new()
+            .read(true)
+            .open(&src)
+            .map_err(mkerror)?;
+        let md = fsrc.metadata().map_err(mkerror)?;
+        assert!(md.is_file());
+
+        /*
+         * Create the target file with the correct mode.  We made sure to remove
+         * it earlier, so we should make sure we are creating it anew here.
+         */
+        let fdst = std::fs::OpenOptions::new()
+            .mode(md.mode())
+            .create_new(true)
+            .write(true)
+            .open(&dst)
+            .map_err(mkerror)?;
+
+        /*
+         * The easiest way to copy a file, std::fs::copy(), appears to use a
+         * regrettably microscopic buffer for reads and writes.  To make things
+         * go quite a lot faster, create a buffered reader and writer with a
+         * large buffer and use std::io::copy() instead, which will size read
+         * and write calls based on that buffer size.
+         */
+        let cap = 1024 * 1024;
+        let mut bsrc = std::io::BufReader::with_capacity(cap, fsrc);
+        let mut bdst = std::io::BufWriter::with_capacity(cap, fdst);
+
+        cs.bytes += std::io::copy(&mut bsrc, &mut bdst).map_err(mkerror)?;
+    }
+}

--- a/utils/src/defaults.rs
+++ b/utils/src/defaults.rs
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024 Oxide Computer Company
+ */
+
+use std::{collections::HashMap, mem, path::Path, str::FromStr};
+
+use anyhow::{bail, Result};
+
+/**
+ * An extremely minimal parser for a subset of defaults files, as potentially
+ * read by defopen() in "lib/libc/port/gen/deflt.c".
+ */
+#[derive(Debug)]
+pub struct DefaultsFile {
+    values: HashMap<String, String>,
+}
+
+impl DefaultsFile {
+    pub fn get_usize<S: AsRef<str>>(&self, name: S) -> Option<usize> {
+        self.values.get(name.as_ref()).and_then(|v| v.parse().ok())
+    }
+
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<DefaultsFile> {
+        let path = path.as_ref();
+
+        match std::fs::read_to_string(path) {
+            Ok(s) => Ok(DefaultsFile::from_str(s.as_str())?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                /*
+                 * If the file is merely missing, pretend it was empty instead.
+                 */
+                Ok(DefaultsFile {
+                    values: Default::default(),
+                })
+            }
+            Err(e) => bail!("could not load defaults from {path:?}: {e}"),
+        }
+    }
+}
+
+impl FromStr for DefaultsFile {
+    type Err = anyhow::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        enum State {
+            Rest,
+            Comment,
+            Key,
+            Value,
+        }
+
+        let mut l = 1;
+        let mut s = State::Rest;
+        let mut k = String::new();
+        let mut v = String::new();
+        let mut values = HashMap::new();
+
+        for c in input.chars() {
+            match s {
+                State::Rest => {
+                    if c == '#' {
+                        s = State::Comment;
+                    } else if c == '\n' {
+                        l += 1;
+                    } else if c.is_ascii_alphabetic() {
+                        k.clear();
+                        k.push(c);
+                        s = State::Key;
+                    } else {
+                        bail!("unexpected character {c:?}, line {l}");
+                    }
+                }
+                State::Comment => {
+                    if c == '\n' {
+                        l += 1;
+                        s = State::Rest;
+                    } else if c.is_ascii_control() && c != '\t' {
+                        bail!("unexpected character {c:?}, line {l}");
+                    }
+                }
+                State::Key => {
+                    if c == '#' {
+                        bail!("unexpected comment in key name, line {l}");
+                    } else if c.is_ascii_alphanumeric() || c == '_' {
+                        k.push(c);
+                    } else if c == '=' {
+                        v.clear();
+                        s = State::Value;
+                    } else {
+                        bail!("unexpected character {c:?}, line {l}");
+                    }
+                }
+                State::Value => {
+                    if c == '#' || c == '\n' {
+                        values.insert(
+                            mem::take(&mut k),
+                            mem::take(&mut v).trim().to_string(),
+                        );
+                        s = if c == '#' {
+                            State::Comment
+                        } else {
+                            State::Rest
+                        };
+                    } else if c.is_ascii_graphic() || c == ' ' {
+                        v.push(c);
+                    }
+                }
+            }
+        }
+
+        Ok(DefaultsFile { values })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_brand_file() {
+        let input = concat!(
+            "#\n",
+            "# Copyright 2024 Oxide Computer Company\n",
+            "#\n",
+            "\n",
+            "#\n",
+            "# How many writer threads should we use when copying\n",
+            "# from the root file system in a new zone root?\n",
+            "#\n",
+            "COPY_THREADS=16\n",
+            "\n",
+            "#\n",
+            "# What batch size should we use for the copy queue?\n",
+            "#\n",
+            "COPY_BATCH=32\n",
+            "\n",
+            "#\n",
+            "# This is not well-formed.\n",
+            "#\n",
+            "COPY_WHO_I_AM=Mr. Stephens?! Head of Catering?!\n",
+            "\n",
+        );
+
+        let df = DefaultsFile::from_str(&input).expect("parsed output");
+        println!("df = {df:#?}");
+
+        assert_eq!(df.get_usize("COPY_THREADS"), Some(16));
+        assert_eq!(df.get_usize("COPY_BATCH"), Some(32));
+        assert_eq!(df.get_usize("COPY_WHO_I_AM"), None);
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,8 +1,9 @@
 /*
- * Copyright 2023 Oxide Computer Company
+ * Copyright 2024 Oxide Computer Company
  */
 
 #[allow(clippy::many_single_char_names)]
 pub mod ips;
 pub mod metadata;
 pub mod tree;
+pub mod copyq;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -2,8 +2,8 @@
  * Copyright 2024 Oxide Computer Company
  */
 
+pub mod copyq;
 #[allow(clippy::many_single_char_names)]
 pub mod ips;
 pub mod metadata;
 pub mod tree;
-pub mod copyq;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,6 +3,7 @@
  */
 
 pub mod copyq;
+pub mod defaults;
 #[allow(clippy::many_single_char_names)]
 pub mod ips;
 pub mod metadata;

--- a/utils/src/tree.rs
+++ b/utils/src/tree.rs
@@ -3,8 +3,6 @@
  */
 
 use anyhow::{anyhow, bail, Context, Result};
-use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::copyq::{CopyQueue, CopyStats};

--- a/utils/src/tree.rs
+++ b/utils/src/tree.rs
@@ -58,8 +58,8 @@ pub fn replicate<S: AsRef<Path>, T: AsRef<Path>>(
     let df = DefaultsFile::from_path("/etc/default/helios-omicron1")?;
 
     let mut cq = CopyQueue::new(
-        df.get_usize("COPY_THREADS").unwrap_or(16),
-        df.get_usize("COPY_BATCH").unwrap_or(32),
+        df.get_usize("COPY_THREADS").unwrap_or(8),
+        df.get_usize("COPY_BATCH").unwrap_or(128),
     )?;
 
     let walk = walkdir::WalkDir::new(src).same_file_system(true);


### PR DESCRIPTION
This change improves zone install performance through two means:

- It seems like **std::fs::copy()** uses a deeply regrettable 8KB buffer size for each **read()** and **write()**, which makes for a lot of system call overhead.  I haven't confirmed the details, but it seems like this may perhaps be surprisingly pathological in the case of a ZFS pool with **gzip-9** compression.  Restructuring the copy code so that we can increase this buffer size to 1MB improves throughput a fair bit.
- Our computers are quite wide, so we'll create 16 threads to offload the heavy lifting of the file copy operation.

On the Gimlet where I did a brief smoke test, we go from:

```
gimlet-sn07 # zoneadm -z test uninstall -F ; ptime -m zoneadm -z test install
INFO: omicron: uninstalling zone test...
INFO: omicron: installing zone test @ "/data/zones/test"...
INFO: omicron: replicating /usr tree...
INFO: omicron: replicating /lib tree...
INFO: omicron: replicating /sbin tree...
INFO: omicron: pruning SMF manifests...
INFO: omicron: pruning global-only files...
INFO: omicron: unpacking baseline archive...
INFO: omicron: copying /etc/default/init...
INFO: omicron: install complete, probably!

real        7.748228113
user        0.256719377
sys         2.142117414
trap        0.000018704
tflt        0.000000000
dflt        0.000003035
kflt        0.000000000
lock        0.004332631
slp        20.370977556
lat         0.094301330
stop        0.000364079
```

... to ...

```
gimlet-sn07 # zoneadm -z test uninstall -F ; ptime -m zoneadm -z test install
INFO: omicron: uninstalling zone test...
INFO: omicron: installing zone test @ "/data/zones/test"...
INFO: omicron: replicating /usr tree...
INFO: omicron: replicated /usr: 9514 files, 121518507, bytes, 562 msec
INFO: omicron: replicating /lib tree...
INFO: omicron: replicated /lib: 163 files, 2849749, bytes, 21 msec
INFO: omicron: replicating /sbin tree...
INFO: omicron: replicated /sbin: 0 files, 0, bytes, 1 msec
INFO: omicron: pruning SMF manifests...
INFO: omicron: pruning global-only files...
INFO: omicron: unpacking baseline archive...
INFO: omicron: copying /etc/default/init...
INFO: omicron: install complete, probably!

real        0.945731000
user        0.409957787
sys         3.937423102
trap        0.000085716
tflt        0.000028022
dflt        0.000026368
kflt        0.000041306
lock        4.048764217
slp         2.708285516
lat         0.076202687
stop        0.000471146
```

... which is at least a bit faster!

**NOTE:** I have not yet done any serious verification of the actual result of the copies here.  It appears to work, and I have spot checked a file here and there, but I'll want to do a more rigorous evaluation of both the metadata and the contents of the files as a result of this change.