### PR TITLE
Allow `variant.illumos.debug` field on IPS depend.

### DIFF
--- a/utils/src/ips.rs
+++ b/utils/src/ips.rs
@@ -214,6 +214,7 @@ pub struct ActionDepend {
     fmri: Vec<Package>,
     type_: DependType,
     predicate: Vec<String>,
+    debug: Option<String>,
 }
 
 impl ActionDepend {
@@ -227,6 +228,10 @@ impl ActionDepend {
 
     pub fn type_(&self) -> DependType {
         self.type_
+    }
+
+    pub fn debug(&self) -> Option<&String> {
+        self.debug.as_ref()
     }
 }
 
@@ -527,6 +532,7 @@ pub fn parse_manifest(input: &str) -> Result<Vec<Action>> {
                     .collect::<Result<Vec<_>>>()?;
                 let type_ = vals.single("type")?.try_into()?;
                 let predicate = vals.maybe_list("predicate");
+                let debug = vals.maybe_single("variant.debug.illumos")?;
                 /*
                  * XXX Ignore...
                  */
@@ -538,6 +544,7 @@ pub fn parse_manifest(input: &str) -> Result<Vec<Action>> {
                     fmri,
                     type_,
                     predicate,
+                    debug,
                 })
             }
             "dir" => {


### PR DESCRIPTION
Allows package dependencies to be conditional on whether a debug variant is selected. I'm unsure whether we should be extending this to `File` etc., given that we'll have several entries mapping different objects to the same path:

```
file 271e9b82ede6060d1f563e2baf63f5e6d8fa044b ... path=kernel/drv/amd64/xde ... variant.debug.illumos=false variant.opensolaris.zone=global
file 205529450cb037486808d28640d6831a85189df4 ... path=kernel/drv/amd64/xde ... variant.debug.illumos=true variant.opensolaris.zone=global
```

Today this isn't prevented with a `check_for_extra()` or the like.

Closes #13.