### PR TITLE
Switch to helios3; include helios version in package FMRI

### DIFF
--- a/.github/buildomat/jobs/pkg.sh
+++ b/.github/buildomat/jobs/pkg.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "pkg"
 #: variety = "basic"
-#: target = "helios-2.0-20240204"
+#: target = "helios-3.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:	"=/out/omicron-brand.p5p",

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 #
-# Copyright 2024 Oxide Computer Company
+# Copyright 2026 Oxide Computer Company
 #
 
 TOP =		$(PWD)
 
-PUBLISHER =	helios-dev
+PUBLISHER =	helios
 
 PROTO =		$(TOP)/proto
 PKGDIR =	$(TOP)/packages
@@ -44,6 +44,10 @@ PACKAGES_0 =	brand \
 		incorporation
 PACKAGES =	$(PACKAGES_0:%=pkg.%)
 
+HELIOS_RELEASE = $(or \
+    $(shell awk -F= '/^VERSION=/{print $$2}' /etc/os-release), \
+    2)
+CVER = 0
 COMMIT_COUNT =	$(shell git rev-list --count HEAD)
 
 .PHONY: all
@@ -61,6 +65,8 @@ $(PKGDIR)/%.base.p5m: pkg/%.p5m | $(PKGDIR)
 	@rm -f $@
 	sed -e 's/%PUBLISHER%/$(PUBLISHER)/g' \
 	    -e 's/%COMMIT_COUNT%/$(COMMIT_COUNT)/g' \
+	    -e 's/%HELIOS_RELEASE%/$(HELIOS_RELEASE)/g' \
+	    -e 's/%CVER%/$(CVER)/g' \
 	    $< | pkgmogrify -v -O $@
 
 .PRECIOUS: $(PKGDIR)/%.generate.p5m

--- a/pkg/baseline.p5m
+++ b/pkg/baseline.p5m
@@ -1,8 +1,8 @@
 #
-# Copyright 2024 Oxide Computer Company
+# Copyright 2026 Oxide Computer Company
 #
 set name=pkg.fmri \
-    value=pkg://%PUBLISHER%/system/zones/brand/omicron1/tools@1.0.%COMMIT_COUNT%
+    value=pkg://%PUBLISHER%/system/zones/brand/omicron1/tools@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%
 set name=pkg.summary value="Oxide omicron1 brand development tools"
 set name=info.classification \
     value=org.opensolaris.category.2008:System/Virtualization
@@ -20,5 +20,5 @@ dir  path=usr/lib/brand owner=root group=bin mode=0755
 dir  path=usr/lib/brand/omicron1 owner=root group=sys mode=0755
 file path=usr/lib/brand/omicron1/baseline owner=root group=bin mode=0755
 depend type=require \
-    fmri=pkg:/consolidation/oxide/omicron1-brand-incorporation@1.0.%COMMIT_COUNT%
-depend type=require fmri=pkg:/system/zones/brand/omicron1@1.0.%COMMIT_COUNT%
+    fmri=pkg:/consolidation/oxide/omicron1-brand-incorporation@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%
+depend type=require fmri=pkg:/system/zones/brand/omicron1@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%

--- a/pkg/brand.p5m
+++ b/pkg/brand.p5m
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Oxide Computer Company
+# Copyright 2026 Oxide Computer Company
 #
 
 #
@@ -7,7 +7,7 @@
 #
 <transform dir file link hardlink -> default variant.opensolaris.zone global>
 set name=pkg.fmri \
-    value=pkg://%PUBLISHER%/system/zones/brand/omicron1@1.0.%COMMIT_COUNT%
+    value=pkg://%PUBLISHER%/system/zones/brand/omicron1@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%
 set name=pkg.summary value="Oxide omicron1 brand support"
 set name=info.classification \
     value=org.opensolaris.category.2008:System/Virtualization
@@ -29,4 +29,4 @@ dir  path=usr/share/man owner=root group=bin mode=0755
 dir  path=usr/share/man/man7 owner=root group=bin mode=0755
 file path=usr/share/man/man7/omicron1.7 owner=root group=bin mode=0444
 depend type=require \
-    fmri=pkg:/consolidation/oxide/omicron1-brand-incorporation@1.0.%COMMIT_COUNT%
+    fmri=pkg:/consolidation/oxide/omicron1-brand-incorporation@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%

--- a/pkg/incorporation.p5m
+++ b/pkg/incorporation.p5m
@@ -1,13 +1,13 @@
 #
-# Copyright 2024 Oxide Computer Company
+# Copyright 2026 Oxide Computer Company
 #
 
 set name=pkg.fmri \
-    value=pkg://%PUBLISHER%/consolidation/oxide/omicron1-brand-incorporation@1.0.%COMMIT_COUNT%
+    value=pkg://%PUBLISHER%/consolidation/oxide/omicron1-brand-incorporation@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%
 set name=pkg.summary value="Incorporation to constrain omicron1 brand version"
 set name=info.classification \
     value="org.opensolaris.category.2008:Meta Packages/Incorporations"
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend type=incorporate \
-    fmri=pkg:/system/zones/brand/omicron1/tools@1.0.%COMMIT_COUNT%
-depend type=incorporate fmri=pkg:/system/zones/brand/omicron1@1.0.%COMMIT_COUNT%
+    fmri=pkg:/system/zones/brand/omicron1/tools@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%
+depend type=incorporate fmri=pkg:/system/zones/brand/omicron1@1.0.%COMMIT_COUNT%-%HELIOS_RELEASE%.%CVER%


### PR DESCRIPTION
Make the package names consistent and include the helios release in the dash component.
Heliosv3 uses the `helios` publisher.